### PR TITLE
fix: mastered book governance target urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ This work is licensed under CC BY-NC-ND 4.0 <a href="https://creativecommons.org
 
 [pandoc]: https://pandoc.org
 [pandoc-docker]: https://github.com/pandoc/dockerfiles
-[semaphore-project]: https://semaphore-oss.semaphoreci.com/projects/book-cicd-docker-kubernetes
+[semaphore-project]: https://semaphore-oss.semaphoreci.com/projects/book-monorepo-cicd

--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -19,7 +19,7 @@ $MONTHYEAR: First edition v1.0 (revision $REVISION)
 
 Share this book:
 
-> _I've just started reading "CI/CD for Monorepoes", a free ebook by @semaphoreci: TODO:link https://bit.ly/3bJELLQ ([Tweet this!](TODO: link https://ctt.ac/c5Ub9))_
+> _I've just started reading "CI/CD for Monorepoes", a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](TODO: link https://ctt.ac/c5Ub9))_
 
 \newpage
 

--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -19,7 +19,7 @@ $MONTHYEAR: First edition v1.0 (revision $REVISION)
 
 Share this book:
 
-> _I've just started reading "CI/CD for Monorepoes", a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](TODO: link https://ctt.ac/c5Ub9))_
+> _I've just started reading "CI/CD for Monorepoes", a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
 
 \newpage
 

--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -8,7 +8,7 @@ To view a copy of this license, visit
 <https://creativecommons.org/licenses/by-nc-nd/4.0>
 
 This book is open source:
-<https://github.com/semaphoreci/book-cicd-docker-kubernetes>
+<https://github.com/semaphoreci/book-monorepo-cicd>
 
 Published on the Semaphore website:
 [https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=monorepo-cicd)

--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -11,7 +11,7 @@ This book is open source:
 <https://github.com/semaphoreci/book-cicd-docker-kubernetes>
 
 Published on the Semaphore website:
-[https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=cicd-docker-kubernetes-semaphore)
+[https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=monorepo-cicd)
 
 $MONTHYEAR: First edition v1.0 (revision $REVISION)
 

--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -19,7 +19,7 @@ $MONTHYEAR: First edition v1.0 (revision $REVISION)
 
 Share this book:
 
-> _I've just started reading "CI/CD for Monorepoes", a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
+> _I've just started reading "CI/CD for Monorepos", a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
 
 \newpage
 

--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -19,7 +19,7 @@ $MONTHYEAR: First edition v1.0 (revision $REVISION)
 
 Share this book:
 
-> _I’ve just started reading “CI/CD for Monorepos,” a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
+> _I’ve just started reading “CI/CD for Monorepos”, a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
 
 \newpage
 

--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -19,7 +19,7 @@ $MONTHYEAR: First edition v1.0 (revision $REVISION)
 
 Share this book:
 
-> _I’ve just started reading “CI/CD for Monorepos,” a free ebook by @semaphoreci: https://bit.ly/3yopUT2([Tweet this!](https://ctt.ac/dL5z4))_
+> _I’ve just started reading “CI/CD for Monorepos,” a free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Tweet this!](https://ctt.ac/dL5z4))_
 
 \newpage
 

--- a/chapters/06-final-words-ebook.md
+++ b/chapters/06-final-words-ebook.md
@@ -15,7 +15,7 @@ Share the book on Twitter:
 You can also share it TODO:links
 [on Facebook](https://www.facebook.com/sharer/sharer.php?u=https://bit.ly/3bJELLQ), share it [on
 LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https://bit.ly/3bJELLQ) and star the repository
-[on GitHub](https://github.com/semaphoreci/book-cicd-docker-kubernetes).
+[on GitHub](https://github.com/semaphoreci/book-monorepo-cicd).
 
 ## 5.2 Tell Us What You Think
 

--- a/chapters/06-final-words-ebook.md
+++ b/chapters/06-final-words-ebook.md
@@ -31,4 +31,4 @@ This book is open source and available at
 
 ## 5.3 About Semaphore
 
-Semaphore [https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=cicd-for-monorepos) helps developers continuously build, test and deploy code at the push of a button. It provides the fastest, enterprise-grade CI/CD pipelines as a serverless service. Trusted by thousands of organizations around the globe, Semaphore can help your team move faster too.
+Semaphore [https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=monorepo-cicd) helps developers continuously build, test and deploy code at the push of a button. It provides the fastest, enterprise-grade CI/CD pipelines as a serverless service. Trusted by thousands of organizations around the globe, Semaphore can help your team move faster too.

--- a/chapters/06-final-words-ebook.md
+++ b/chapters/06-final-words-ebook.md
@@ -6,13 +6,13 @@ TODO: write section
 
 ## 5.1 Share This Book With The World
 
-Please share this book with your colleagues, friends and anyone who you think might benefit from it.
+Please share this book with your colleagues, friends, and anyone who you think might benefit from it.
 
 Share the book on Twitter:
 
-> _Learn CI/CD for Monorepos with this free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Click to Tweet!](https://ctt.ac/dL5z4))_
+> _Learn "CI/CD for Monorepos" with this free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Click to Tweet!](https://ctt.ac/dL5z4))_
 
-You can also share it TODO:links
+You can also share it 
 [on Facebook](https://www.facebook.com/sharer/sharer.php?u=https://bit.ly/3yopUT2), share it [on
 LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https://bit.ly/3yopUT2) and star the repository
 [on GitHub](https://github.com/semaphoreci/book-monorepo-cicd).

--- a/chapters/06-final-words-ebook.md
+++ b/chapters/06-final-words-ebook.md
@@ -10,11 +10,11 @@ Please share this book with your colleagues, friends and anyone who you think mi
 
 Share the book on Twitter:
 
-> _Learn CI/CD for Monorepos with this free ebook by @semaphoreci:TODO:link https://bit.ly/3bJELLQ ([Click to Tweet!](https://ctt.ac/fL5xi))_
+> _Learn CI/CD for Monorepos with this free ebook by @semaphoreci: https://bit.ly/3yopUT2 ([Click to Tweet!](https://ctt.ac/dL5z4))_
 
 You can also share it TODO:links
-[on Facebook](https://www.facebook.com/sharer/sharer.php?u=https://bit.ly/3bJELLQ), share it [on
-LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https://bit.ly/3bJELLQ) and star the repository
+[on Facebook](https://www.facebook.com/sharer/sharer.php?u=https://bit.ly/3yopUT2), share it [on
+LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https://bit.ly/3yopUT2) and star the repository
 [on GitHub](https://github.com/semaphoreci/book-monorepo-cicd).
 
 ## 5.2 Tell Us What You Think


### PR DESCRIPTION
### PROBLEM

- Some urls on the pdf and ebook remains pointing to previous book.
- Minor typos & grammar mistakes near to that urls

### SOLUTION

- `TODO:link` are solved.
- Typos and & grammar are solved with the proupose of homogeneize the texts across pdf - ebook.

---

I hope this helps to improve a bit this new book.

Nice job team!
